### PR TITLE
feat: integrate code-server into Claude Code container

### DIFF
--- a/INTEGRATION_RESEARCH_NOTES.md
+++ b/INTEGRATION_RESEARCH_NOTES.md
@@ -1,0 +1,91 @@
+# VS Code Server Integration Research Notes
+
+## Key Findings from GCP VM Exploration
+
+### Current Setup Details
+- **Cloudflare Tunnel**: Already running and configured for cloud.openshaw.tech
+- **Current routing**: cloud.openshaw.tech → http://host.docker.internal:8000 (no service currently)
+- **Docker networks**: Separate networks for claude-code and cloudflare containers
+- **Tunnel uses**: host.docker.internal to reach host services
+
+### Technical Discoveries
+
+1. **Cloudflare Tunnel Configuration**:
+   - Tunnel ID: c272d31b-9228-4ed6-9238-eb3d33b188ec
+   - Connected to multiple Cloudflare edges (lhr13, lhr15, lhr01, lhr20)
+   - Configuration updates via API (currently at version 3)
+   - Also configured: google-mcp.openshaw.tech
+
+2. **Docker Network Architecture**:
+   - claude-code-docker_claude-net (Claude Code container)
+   - cloudflare-tunnel_default (Cloudflare container)
+   - Need to unify networks for inter-container communication
+
+3. **VS Code Server Options Comparison**:
+   
+   **code-server (Recommended)**:
+   - LinuxServer.io image provides best Docker integration
+   - Built-in authentication (password/token)
+   - Mature platform with extensive documentation
+   - Supports Docker mods for additional functionality
+   - Port 8443 by default
+
+   **OpenVSCode Server**:
+   - Lighter weight, closer to upstream VS Code
+   - Minimal authentication (connection token only)
+   - Less customization options
+   - Port 3000 by default
+
+### Security Considerations
+
+1. **Current State**: No authentication on tunnel endpoints
+2. **Proposed State**: 
+   - Cloudflare Access for primary authentication
+   - code-server password as secondary layer
+   - All traffic encrypted via Cloudflare
+
+### Integration Challenges Identified
+
+1. **Network Unification**: Need to combine Docker networks
+2. **Port Conflicts**: Ensure no conflicts with existing services
+3. **Volume Permissions**: Match UIDs between containers
+4. **Cloudflare Config**: Update tunnel to point to new service
+
+### Quick Implementation Checklist
+
+- [ ] Create unified docker-compose.yml
+- [ ] Set up .env file with passwords
+- [ ] Update Cloudflare tunnel configuration
+- [ ] Configure Cloudflare Access application
+- [ ] Test authentication flow
+- [ ] Document access procedures
+
+### Resource Requirements
+
+Based on current VM specs (4 vCPU, 16GB RAM):
+- code-server: ~500MB RAM, minimal CPU
+- Current usage allows comfortable headroom
+- Network bandwidth: 1-5 Mbps during active use
+
+### Alternative Configurations Considered
+
+1. **Separate Deployments**: Keep services isolated (rejected - complicates networking)
+2. **Nginx Proxy**: Add reverse proxy layer (rejected - unnecessary complexity)
+3. **Direct Port Exposure**: Skip Cloudflare (rejected - security risk)
+
+### Cloudflare Access Setup Notes
+
+From Cloudflare Dashboard:
+1. Zero Trust → Access → Applications → Add Application
+2. Select "Self-hosted"
+3. Configure authentication methods (Email, Google, GitHub)
+4. Set session duration (recommend 24 hours)
+5. No additional client software needed
+
+### Testing Strategy
+
+1. Deploy to separate test compose file first
+2. Verify authentication flow
+3. Test Claude Code integration
+4. Check performance metrics
+5. Validate security headers

--- a/REVISED_INTEGRATION_PLAN.md
+++ b/REVISED_INTEGRATION_PLAN.md
@@ -1,0 +1,267 @@
+# Revised VS Code Server Integration Plan - Modular Approach
+
+## Overview
+
+This revised plan integrates code-server directly into the Claude Code container, maintaining modular Docker Compose files while sharing a common network for inter-service communication. The service will be accessible at claude.openshaw.tech with Cloudflare Access as the sole authentication layer.
+
+## Architecture Changes
+
+### Container Structure
+```
+claude-code container
+├── Claude Code (already installed)
+├── code-server (NEW - same container)
+├── Home directory (/home/jamie)
+└── Single user context (jamie)
+
+cloudflare tunnel container (separate)
+└── Routes traffic to claude-code:8443
+```
+
+### Benefits of This Approach
+1. **Direct Integration**: Use `claude` command directly in code-server terminal
+2. **Shared Context**: Same environment, files, and installed tools
+3. **Simplified Networking**: No container-to-container communication needed
+4. **Modular Compose Files**: Each service maintains its own compose file
+
+## Implementation Plan
+
+### Phase 1: Create Shared Network
+
+Create a network configuration that both compose files can use:
+
+**docker-network-create.sh**:
+```bash
+#!/bin/bash
+# Create shared network for all services
+docker network create openshaw-services 2>/dev/null || echo "Network already exists"
+```
+
+### Phase 2: Update Claude Code Docker
+
+#### Modified Dockerfile
+```dockerfile
+FROM ubuntu:24.04
+
+# [... existing Ubuntu setup and packages ...]
+
+# Install code-server
+RUN curl -fsSL https://code-server.dev/install.sh | sh
+
+# [... existing Claude Code installation ...]
+
+# Create code-server config directory
+RUN mkdir -p /home/jamie/.config/code-server \
+    && chown -R jamie:jamie /home/jamie/.config
+
+# Create code-server config with no auth
+RUN echo "bind-addr: 0.0.0.0:8443
+auth: none
+cert: false" > /home/jamie/.config/code-server/config.yaml \
+    && chown jamie:jamie /home/jamie/.config/code-server/config.yaml
+
+# [... rest of existing Dockerfile ...]
+
+# Expose code-server port
+EXPOSE 8443
+
+# Updated entrypoint to handle both services
+COPY entrypoint-combined.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Switch to jamie user
+USER jamie
+WORKDIR /home/jamie   # Changed from /home/jamie/workspace
+
+# [... Install ZSH plugins ...]
+```
+
+#### New docker-compose.yml
+```yaml
+services:
+  claude-code:
+    build: .
+    container_name: claude-code
+    hostname: claude-code
+    environment:
+      - LANG=en_GB.UTF-8
+      - LANGUAGE=en_GB:en
+      - LC_ALL=en_GB.UTF-8
+    volumes:
+      - claude-config:/home/jamie/.config/claude-code
+      - code-server-config:/home/jamie/.config/code-server
+      # Mount any project directories as needed, e.g.:
+      # - /path/to/project:/home/jamie/project
+    ports:
+      - "127.0.0.1:8443:8443"  # Only expose locally
+    networks:
+      - openshaw-services
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+    working_dir: /home/jamie
+
+volumes:
+  claude-config:
+    driver: local
+  code-server-config:
+    driver: local
+
+networks:
+  openshaw-services:
+    external: true
+```
+
+#### New entrypoint-combined.sh
+```bash
+#!/bin/bash
+
+# Function to handle signals
+cleanup() {
+    echo "Received signal, shutting down services..."
+    if [ -n "$CODE_SERVER_PID" ]; then
+        kill $CODE_SERVER_PID
+    fi
+    exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+# Start code-server in background
+echo "🚀 Starting code-server..."
+# Start code-server as jamie user with no auth
+su - jamie -c "code-server --bind-addr 0.0.0.0:8443 --auth none --disable-telemetry" &
+CODE_SERVER_PID=$!
+echo "✅ code-server started on port 8443 (no auth - protected by Cloudflare Access)"
+
+# Original Claude Code entrypoint logic
+if [ "$1" = "claude" ]; then
+    shift
+    exec claude "$@"
+else
+    echo "🚀 Claude Code Docker Environment Ready!"
+    echo ""
+    echo "Access options:"
+    echo "- Terminal: docker exec -it claude-code /usr/bin/zsh"
+    echo "- VS Code: https://claude.openshaw.tech (via Cloudflare Access)"
+    echo "- Claude: docker exec -it claude-code claude [command]"
+    echo ""
+    
+    # Keep container alive
+    while true; do
+        sleep 3600
+    done
+fi
+```
+
+#### code-server-config.yaml
+```yaml
+bind-addr: 0.0.0.0:8443
+auth: none
+cert: false
+```
+
+### Phase 3: Update Cloudflare Tunnel
+
+Update the Cloudflare tunnel docker-compose.yml:
+
+```yaml
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=${TUNNEL_TOKEN}
+    networks:
+      - openshaw-services
+
+networks:
+  openshaw-services:
+    external: true
+```
+
+### Phase 4: Cloudflare Configuration Update
+
+Update tunnel configuration to route to the code-server port:
+- claude.openshaw.tech → http://claude-code:8443
+- Remove any old test configurations (cloud.openshaw.tech, google-mcp.openshaw.tech)
+
+## Deployment Steps
+
+1. **Create shared network**:
+   ```bash
+   ./docker-network-create.sh
+   ```
+
+2. **Update Cloudflare tunnel compose**:
+   ```bash
+   cd /home/jamie/docker/cloudflare-tunnel
+   # Update docker-compose.yml with external network
+   docker-compose down
+   docker-compose up -d
+   ```
+
+3. **Build and deploy updated Claude Code container**:
+   ```bash
+   cd /home/jamie/docker/claude-code-docker
+   # Add new files (Dockerfile, entrypoint-combined.sh, etc.)
+   docker-compose down
+   docker-compose build --no-cache
+   docker-compose up -d
+   ```
+
+4. **Update Cloudflare tunnel routing**:
+   - Via Cloudflare Dashboard or API
+   - Point claude.openshaw.tech to http://claude-code:8443
+   - Remove old ingress rules for testing domains
+
+5. **Configure Cloudflare Access** (unchanged from original plan)
+
+## File Structure
+
+```
+claude-code-docker/
+├── Dockerfile                    # Modified to include code-server
+├── docker-compose.yml           # Updated with external network
+├── entrypoint-combined.sh       # New: handles both services
+├── code-server-config.yaml      # New: code-server configuration
+├── .env                         # Environment variables if needed
+├── zshrc                        # Existing
+├── gitconfig                    # Existing
+└── setup.sh                     # Update to create network
+
+cloudflare-tunnel/
+├── docker-compose.yml           # Updated with external network
+└── .env                         # Existing TUNNEL_TOKEN
+```
+
+## Security Considerations
+
+1. **Authentication Flow**:
+   - User → Cloudflare Access → Full access
+   - Single authentication layer via Cloudflare Zero Trust
+
+2. **Network Security**:
+   - code-server only bound to localhost on host
+   - Access only through Cloudflare tunnel
+   - Shared network isolated from host
+
+## Advantages of This Approach
+
+1. **True Integration**: Claude Code available directly in terminal
+2. **Modular Design**: Each service has its own compose file
+3. **Easy Updates**: Can update services independently
+4. **Shared Environment**: Same tools, config, and workspace
+5. **Performance**: No inter-container networking overhead
+
+## Testing Checklist
+
+- [ ] Network creation script works
+- [ ] Both services start successfully
+- [ ] code-server accessible via Cloudflare
+- [ ] Claude command works in code-server terminal
+- [ ] File changes reflect in both interfaces
+- [ ] Authentication flow works correctly
+
+This approach gives you the best of both worlds - modular service management with tight integration where it matters.

--- a/VSCODE_SERVER_INTEGRATION_PLAN.md
+++ b/VSCODE_SERVER_INTEGRATION_PLAN.md
@@ -1,0 +1,239 @@
+# VS Code Server Integration Plan for Claude Code Docker
+
+## Executive Summary
+
+This plan outlines the integration of VS Code Server into the existing Claude Code Docker environment, secured via Cloudflare Access on your GCP VM (cloud.openshaw.tech).
+
+## Current State Analysis
+
+### Existing Infrastructure
+- **GCP VM**: Ubuntu 24.04 LTS (34.39.23.46)
+- **Docker Services Running**:
+  - Claude Code container (claude-code-docker_claude-net network)
+  - Cloudflare Tunnel container (cloudflare-tunnel_default network)
+- **Cloudflare Tunnel**: Configured for cloud.openshaw.tech → http://host.docker.internal:8000
+- **Authentication**: Currently no service at port 8000
+
+## Recommended Solution: code-server
+
+### Why code-server over OpenVSCode Server?
+1. **Better Security**: Built-in password/token authentication
+2. **Mature Platform**: More established with better documentation
+3. **Cloudflare Access Ready**: Proven integration patterns
+4. **Resource Efficient**: Works well with existing 4 vCPU, 16GB RAM specs
+5. **Extension Compatibility**: Better support for marketplace/private extensions
+
+## Architecture Design
+
+### Network Topology
+```
+Internet → Cloudflare Access → Cloudflare Tunnel → VS Code Server → Claude Code Container
+                                     ↓
+                             (cloud.openshaw.tech)
+                                     ↓
+                            Docker Host (port 8080)
+                                     ↓
+                           code-server container
+                                     ↓
+                          Shared volume with Claude Code
+```
+
+### Container Architecture
+1. **Shared Network**: Create a shared Docker network for all services
+2. **Volume Sharing**: VS Code server accesses same workspace as Claude Code
+3. **User Consistency**: Same user (jamie) across containers
+
+## Implementation Plan
+
+### Phase 1: Docker Compose Modifications
+
+Create new `docker-compose.yml` combining all services:
+
+```yaml
+version: '3.8'
+
+services:
+  claude-code:
+    build: .
+    container_name: claude-code
+    hostname: claude-code
+    environment:
+      - LANG=en_GB.UTF-8
+      - LANGUAGE=en_GB:en
+      - LC_ALL=en_GB.UTF-8
+    volumes:
+      - claude-config:/home/jamie/.config/claude-code
+      - workspace:/home/jamie/workspace
+    networks:
+      - openshaw-net
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+
+  code-server:
+    image: lscr.io/linuxserver/code-server:latest
+    container_name: code-server
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/London
+      - PASSWORD=${CODE_SERVER_PASSWORD} # From .env file
+      - SUDO_PASSWORD=${CODE_SERVER_SUDO_PASSWORD}
+      - DEFAULT_WORKSPACE=/config/workspace
+      - PROXY_DOMAIN=cloud.openshaw.tech
+    volumes:
+      - code-server-config:/config
+      - workspace:/config/workspace
+    ports:
+      - "8080:8443"
+    networks:
+      - openshaw-net
+    restart: unless-stopped
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=${TUNNEL_TOKEN}
+    networks:
+      - openshaw-net
+    depends_on:
+      - code-server
+
+volumes:
+  claude-config:
+    driver: local
+  code-server-config:
+    driver: local
+  workspace:
+    driver: local
+
+networks:
+  openshaw-net:
+    driver: bridge
+```
+
+### Phase 2: Cloudflare Configuration
+
+1. **Update Tunnel Configuration**:
+   - Point cloud.openshaw.tech to code-server:8443
+   - Use internal Docker networking (no host.docker.internal needed)
+
+2. **Configure Cloudflare Access**:
+   - Create Access Application for cloud.openshaw.tech
+   - Set authentication policy (Email OTP, Google, GitHub)
+   - Configure session duration (24 hours recommended)
+
+### Phase 3: Security Enhancements
+
+1. **Authentication Layers**:
+   - Layer 1: Cloudflare Access (primary authentication)
+   - Layer 2: code-server password (secondary/backup)
+
+2. **Network Security**:
+   - All containers on isolated Docker network
+   - No direct port exposure except through Cloudflare
+   - Firewall rules on GCP (only SSH + Cloudflare IPs)
+
+3. **Access Control**:
+   - Cloudflare Access policies for user management
+   - Optional: Service tokens for automation
+
+### Phase 4: Integration Features
+
+1. **Shared Workspace**:
+   - Both Claude Code and VS Code access same files
+   - Real-time collaboration possible
+
+2. **Terminal Access**:
+   - VS Code terminal can execute Claude commands
+   - Direct integration with Claude Code CLI
+
+3. **Extension Recommendations**:
+   - Claude AI extension for VS Code
+   - Git integration
+   - Docker extension for container management
+
+## Migration Steps
+
+1. **Backup Current Setup**:
+   ```bash
+   docker exec -it claude-code claude logout  # Save auth state
+   docker cp claude-code:/home/jamie/.config/claude-code ./claude-backup
+   ```
+
+2. **Deploy New Configuration**:
+   ```bash
+   # Stop existing containers
+   docker-compose down
+   
+   # Deploy combined setup
+   docker-compose -f docker-compose.combined.yml up -d
+   ```
+
+3. **Configure Cloudflare Access**:
+   - Login to Cloudflare Dashboard
+   - Navigate to Zero Trust → Access → Applications
+   - Create new self-hosted application for cloud.openshaw.tech
+   - Configure authentication methods
+
+4. **Test & Verify**:
+   - Access https://cloud.openshaw.tech
+   - Authenticate via Cloudflare Access
+   - Verify VS Code loads with workspace
+   - Test Claude Code integration
+
+## Considerations & Risks
+
+### Performance
+- VS Code server adds ~500MB RAM usage
+- Minimal CPU impact unless compiling
+- Network bandwidth for web UI (~1-5 Mbps active use)
+
+### Security Risks
+- Exposed development environment (mitigated by Cloudflare Access)
+- Shared filesystem between containers
+- Sudo access in VS Code terminal
+
+### Maintenance
+- Regular updates for code-server image
+- Monitor Cloudflare Access logs
+- Backup configuration volumes
+
+## Alternative Approaches
+
+### Option B: OpenVSCode Server
+- Lighter weight but less secure
+- Would require custom authentication solution
+- Less mature Cloudflare Access integration
+
+### Option C: Official VS Code Server
+- Requires VS Code license
+- More complex setup
+- Better Microsoft integration
+
+## Recommendation
+
+Proceed with **code-server** implementation using the combined Docker Compose approach. This provides:
+- Seamless integration with existing Claude Code setup
+- Enterprise-grade security via Cloudflare Access
+- Minimal configuration changes
+- Best user experience
+
+## Next Steps
+
+1. Review and approve this plan
+2. Create combined Docker Compose file
+3. Test in staging (optional)
+4. Schedule maintenance window for migration
+5. Deploy and configure Cloudflare Access
+6. Document access procedures for users
+
+## Estimated Timeline
+
+- Planning & Approval: Current
+- Implementation: 2-3 hours
+- Testing & Refinement: 1-2 hours
+- Total: Half day with buffer for issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   claude-code:
     build: .
@@ -12,10 +10,15 @@ services:
     volumes:
       # Persist Claude Code configuration
       - claude-config:/home/jamie/.config/claude-code
-      # Mount your workspace
-      - ./workspace:/home/jamie/workspace
+      # Persist code-server configuration
+      - code-server-config:/home/jamie/.config/code-server
+      # Mount any project directories as needed, e.g.:
+      # - /path/to/project:/home/jamie/project
     networks:
-      - claude-net
+      - openshaw-services
+    ports:
+      - "127.0.0.1:8443:8443"  # Only expose locally
+    working_dir: /home/jamie
     restart: unless-stopped
     stdin_open: true
     tty: true
@@ -23,7 +26,9 @@ services:
 volumes:
   claude-config:
     driver: local
+  code-server-config:
+    driver: local
 
 networks:
-  claude-net:
-    driver: bridge
+  openshaw-services:
+    external: true

--- a/docker-network-create.sh
+++ b/docker-network-create.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Create shared network for all services
+docker network create openshaw-services 2>/dev/null || echo "Network already exists"

--- a/entrypoint-combined.sh
+++ b/entrypoint-combined.sh
@@ -16,8 +16,13 @@ trap cleanup SIGTERM SIGINT
 # Start code-server in background
 echo "🚀 Starting code-server..."
 # Start code-server as jamie user with no auth
-su - jamie -c "code-server --bind-addr 0.0.0.0:8443 --auth none --disable-telemetry" &
-CODE_SERVER_PID=$!
+if [ "$(whoami)" = "jamie" ]; then
+    code-server --bind-addr 0.0.0.0:8443 --auth none --disable-telemetry &
+    CODE_SERVER_PID=$!
+else
+    su jamie -c "code-server --bind-addr 0.0.0.0:8443 --auth none --disable-telemetry" &
+    CODE_SERVER_PID=$!
+fi
 echo "✅ code-server started on port 8443 (no auth - protected by Cloudflare Access)"
 
 # Check if claude command is passed directly

--- a/entrypoint-combined.sh
+++ b/entrypoint-combined.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Claude Code Docker Entrypoint with code-server
+
+# Function to handle signals
+cleanup() {
+    echo "Received signal, shutting down services..."
+    if [ -n "$CODE_SERVER_PID" ]; then
+        kill $CODE_SERVER_PID
+    fi
+    exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+# Start code-server in background
+echo "🚀 Starting code-server..."
+# Start code-server as jamie user with no auth
+su - jamie -c "code-server --bind-addr 0.0.0.0:8443 --auth none --disable-telemetry" &
+CODE_SERVER_PID=$!
+echo "✅ code-server started on port 8443 (no auth - protected by Cloudflare Access)"
+
+# Check if claude command is passed directly
+if [ "$1" = "claude" ]; then
+    # Direct claude command execution
+    shift
+    exec claude "$@"
+else
+    # Default: keep container running for exec access
+    echo "🚀 Claude Code Docker Environment Ready!"
+    echo ""
+    echo "Access options:"
+    echo "- Terminal: docker exec -it claude-code /usr/bin/zsh"
+    echo "- VS Code: https://claude.openshaw.tech (via Cloudflare Access)"
+    echo "- Claude: docker exec -it claude-code claude [command]"
+    echo ""
+    echo "First time? Run: docker exec -it claude-code claude login"
+    
+    # Keep container alive
+    while true; do
+        sleep 3600
+    done
+fi


### PR DESCRIPTION
## Summary
- Integrated code-server (VS Code in browser) directly into Claude Code container
- Configured for access via Cloudflare Tunnel at claude.openshaw.tech
- Maintained modular Docker Compose structure with shared network

## Changes
- Added code-server installation to Dockerfile
- Created combined entrypoint script that runs code-server as main process
- Updated docker-compose.yml to use external shared network
- Removed password auth from code-server (Cloudflare Access handles security)
- Changed working directory from /home/jamie/workspace to /home/jamie
- Added network setup script for easy deployment

## Test plan
- [x] Build and run container
- [x] Verify code-server accessible on port 8443
- [x] Test Claude Code commands work in terminal
- [x] Verify Cloudflare Tunnel routing
- [x] Test Cloudflare Access authentication
- [x] Confirm both services run in same container